### PR TITLE
Flow between modes

### DIFF
--- a/client/src/components/ArenaDoor.js
+++ b/client/src/components/ArenaDoor.js
@@ -4,7 +4,7 @@ import React from "react";
 function ArenaDoor(props) {
   
   return (
-    <>
+    <div className="door">
       {/* <audio src={props.background_music} autoplay></audio> */}
       <h1>{props.name}</h1>
       <img src={props.arena_card} alt="Door"></img>
@@ -21,7 +21,7 @@ function ArenaDoor(props) {
 
         }}>
         Enter Door</button>
-    </>
+    </div>
   );
 }
 

--- a/client/src/components/ArenaDoorList.js
+++ b/client/src/components/ArenaDoorList.js
@@ -17,7 +17,7 @@ function ArenaDoorList(props) {
 
   return (
     <>
-      <h1>Choose your arena!</h1>
+      <div className="title"><h1>Choose your arena!</h1></div>
       {doors}
     </>
   );

--- a/client/src/components/Canvas/Arena.js
+++ b/client/src/components/Canvas/Arena.js
@@ -79,7 +79,6 @@ function Arena(props) {
   }, [health])
 
   // Timings for the challenger's attacks
-  const milliseconds = attackTime / 20;
   const [challengerTimer, setChallengerTimer] = useState(20);
 
   // Use a useEffect to prevent looping (otherwise, every time interval is set, the re-render causes a second timer to be started, etc.)
@@ -93,9 +92,9 @@ function Arena(props) {
       } else {
         setChallengerTimer(prev => prev - 1);
       }
-    }, milliseconds);
+    }, attackTime / 20);
     return () => clearInterval(interval);
-  }, [challengerTimer]);
+  }, [challengerTimer, attackTime]);
 
   // Gets a random word from a words list
   const getRandWord = (action, words) => {
@@ -170,16 +169,16 @@ function Arena(props) {
       </div>
       <div className="challenger-action">
         <div className="buttons">
-          <button onClick={setAttackTime(1000000000)}>Pause</button>
-          <button onClick={setAttackTime(20000)}>Slow</button>
-          <button onClick={setAttackTime(2000)}>Normal</button>
+          <button onClick={() => setAttackTime(1000000000)}>Pause</button>
+          <button onClick={() => setAttackTime(20000)}>Slow</button>
+          <button onClick={() => setAttackTime(2000)}>Normal</button>
         </div>
         <ChallengerActionList
           actions={{
             attack: 'attack-function.jpg',
             timeToAttack: 5
           }}
-          duration={milliseconds}
+          duration={attackTime / 20}
           percentage={challengerTimer / 20 * 100}
         />
       </div>

--- a/client/src/components/Canvas/Arena.js
+++ b/client/src/components/Canvas/Arena.js
@@ -62,18 +62,17 @@ function Arena(props) {
       newHealth[fighter] = Math.min(Math.max(newHealth[fighter] + hp, 0), 100);
       return newHealth;
     });
-    if (health[fighter] === 0) {
-      console.log(`${fighter} DEFEATED`);
-    }
   };
 
   useEffect(() => {
     if (health.player === 0) {
+      props.setResult('LOSEGAME');
       props.setMode("OUTCOME");
       console.log(`PLAYER DEFEATED`);
     } else if (health.challenger === 0) {
-      console.log(`CHALLENGER DEFEATED`);
+      props.setResult('WINBATTLE');
       props.setMode("OUTCOME");
+      console.log(`CHALLENGER DEFEATED`);
       props.setArenas(updateToArenaBeat(props.arenas, props.arena.name))
     }
   }, [health])
@@ -105,7 +104,7 @@ function Arena(props) {
   }
   // Returns true if player input matches an action word
   // const isMatch = (input, actions) => actions.find(action => action.word === input);
-  
+
   // Gets and sets a new word for the given action that the player just executed
   const getNewWord = (action) => {
     setPlayerActions(prev => {

--- a/client/src/components/Canvas/Arena.js
+++ b/client/src/components/Canvas/Arena.js
@@ -27,63 +27,30 @@ function Arena(props) {
   const [health, setHealth] = useState({ player: props.initialPlayerHealth, challenger: props.challengerHealth })
   const [playerInput, setPlayerInput] = useState('');
 
-  const { handleWordMatch, handleLetterMatch } = useInputMatcher();
+  const { handleWordMatch } = useInputMatcher();
 
-  const [match, setMatch] = useState('');
+  // const [match, setMatch] = useState('');
   useEffect(() => {
     console.log('word match?', handleWordMatch(playerInput, playerActions));
-    console.log('letter match?', handleLetterMatch(playerInput, playerActions));
 
-    if (handleLetterMatch(playerInput, playerActions)) {
-      const action = handleWordMatch(playerInput, playerActions);
-      console.log('Action is: ', action);
-      // When finished typing a word, action will equal the name of the action it executes
-      if (action) {
-        // Grab a new word
-        getNewWord(action);
-        // Deal damage
-        switch (action.name) {
-          case 'attack':
-            changeHealth('challenger', -10);
-            break;
-          case 'heal':
-            changeHealth('player', 10);
-        };
-        // Blank the text box
-        setPlayerInput('');
+    const action = handleWordMatch(playerInput, playerActions);
+    // console.log('Action is: ', action);
+    // When finished typing a word, action will equal the name of the action it executes
+    if (action) {
+      // Grab a new word
+      getNewWord(action);
+      // Deal damage
+      switch (action.name) {
+        case 'attack':
+          changeHealth('challenger', -10);
+          break;
+        case 'heal':
+          changeHealth('player', 10);
       };
-
+      // Clear the text box
+      setPlayerInput('');
     };
   }, [playerInput]);
-
-  // // Checking text input for matching letters
-  // useEffect(() =>{
-  //   const inputLen = playerInput.length;
-  //   const maxWordLen = (playerActions.length !== 0) ? Math.max(...playerActions.map(action => action.word.length)) : 0;
-  //   const actionWords = playerActions.map(action => action.word || '')
-  //   const actionWordSlices = actionWords.map(word => word.slice(0, inputLen));
-
-  //   // Check for match if player is shorter or equal to max word length
-  //   if (inputLen > 0 && inputLen <= maxWordLen) {
-  //     // If letter match found
-  //     if (inputLen > 0 && actionWordSlices.includes(playerInput)) {
-  //       // Pass down matching letters
-  //       setMatch(playerInput);
-  //       // If word match found
-  //       if (actionWords.includes(playerInput)) {
-  //         const action = playerActions.find(action => action.word === playerInput);
-  //         // Get a new word for that action
-  //         getNewWord(action)
-
-  //         // Clear text area
-  //         setPlayerInput('');
-  //       }
-  //     } else {
-  //       setMatch('');
-  //     }
-  //   }
-  // }, [playerInput, playerActions]);
-
 
   // Helper functions
 
@@ -151,25 +118,6 @@ function Arena(props) {
     });
   };
 
-  // Check if player input matches an action words
-  // if (isMatch(playerInput, playerActions)) {
-  //   const action = playerActions.find(action => action.word === playerInput);
-  //   // Get a new word for that action
-  //   console.log('matched action', action);
-  //   getNewWord(action);
-  //   // Execute the attack or heal action
-  //   switch (action.name) {
-  //     case 'attack':
-  //       changeHealth('challenger', -10);
-  //       break;
-  //     case 'heal':
-  //       changeHealth('player', 10);
-  //   };
-  //   // Clear text area
-  //   setPlayerInput('')
-  // };
-
-
   // Get word list and action list on load
   useEffect(() => {
     axios.defaults.baseURL = 'http://localhost:3001';
@@ -216,6 +164,7 @@ function Arena(props) {
       <div className="player-action">
         <PlayerActionList
           playerActions={playerActions}
+          playerInput={playerInput}
         />
       </div>
       <div className="challenger-action">

--- a/client/src/components/Canvas/Arena.js
+++ b/client/src/components/Canvas/Arena.js
@@ -14,7 +14,8 @@ import Dummy from '../Dummy';
 import './Arena.scss'
 //helpers
 import updateToArenaBeat from "../../helpers/makeNewArenas";
-
+// Hooks
+import useInputMatcher from '../../hooks/useInputMatcher';
 
 function Arena(props) {
 
@@ -25,8 +26,67 @@ function Arena(props) {
   const [playerActions, setPlayerActions] = useState([]);
   const [health, setHealth] = useState({ player: props.initialPlayerHealth, challenger: props.challengerHealth })
   const [playerInput, setPlayerInput] = useState('');
+
+  const { handleWordMatch, handleLetterMatch } = useInputMatcher();
+
+  const [match, setMatch] = useState('');
+  useEffect(() => {
+    console.log('word match?', handleWordMatch(playerInput, playerActions));
+    console.log('letter match?', handleLetterMatch(playerInput, playerActions));
+
+    if (handleLetterMatch(playerInput, playerActions)) {
+      const action = handleWordMatch(playerInput, playerActions);
+      console.log('Action is: ', action);
+      // When finished typing a word, action will equal the name of the action it executes
+      if (action) {
+        // Grab a new word
+        getNewWord(action);
+        // Deal damage
+        switch (action.name) {
+          case 'attack':
+            changeHealth('challenger', -10);
+            break;
+          case 'heal':
+            changeHealth('player', 10);
+        };
+        // Blank the text box
+        setPlayerInput('');
+      };
+
+    };
+  }, [playerInput]);
+
+  // // Checking text input for matching letters
+  // useEffect(() =>{
+  //   const inputLen = playerInput.length;
+  //   const maxWordLen = (playerActions.length !== 0) ? Math.max(...playerActions.map(action => action.word.length)) : 0;
+  //   const actionWords = playerActions.map(action => action.word || '')
+  //   const actionWordSlices = actionWords.map(word => word.slice(0, inputLen));
+
+  //   // Check for match if player is shorter or equal to max word length
+  //   if (inputLen > 0 && inputLen <= maxWordLen) {
+  //     // If letter match found
+  //     if (inputLen > 0 && actionWordSlices.includes(playerInput)) {
+  //       // Pass down matching letters
+  //       setMatch(playerInput);
+  //       // If word match found
+  //       if (actionWords.includes(playerInput)) {
+  //         const action = playerActions.find(action => action.word === playerInput);
+  //         // Get a new word for that action
+  //         getNewWord(action)
+
+  //         // Clear text area
+  //         setPlayerInput('');
+  //       }
+  //     } else {
+  //       setMatch('');
+  //     }
+  //   }
+  // }, [playerInput, playerActions]);
+
+
   // Helper functions
-  
+
   const changeHealth = (fighter, hp) => {
     console.log(`${fighter} DAMAGED! for ${hp} hp`);
     setHealth(prev => {
@@ -52,7 +112,7 @@ function Arena(props) {
   }, [health])
 
   // Timings for the challenger's attacks
-  const milliseconds = 100;
+  const milliseconds = 1000;
   const [challengerTimer, setChallengerTimer] = useState(20);
 
   // Use a useEffect to prevent looping (otherwise, every time interval is set, the re-render causes a second timer to be started, etc.)
@@ -92,22 +152,22 @@ function Arena(props) {
   };
 
   // Check if player input matches an action words
-  if (isMatch(playerInput, playerActions)) {
-    const action = playerActions.find(action => action.word === playerInput);
-    // Get a new word for that action
-    console.log('matched action', action);
-    getNewWord(action);
-    // Execute the attack or heal action
-    switch (action.name) {
-      case 'attack':
-        changeHealth('challenger', -10);
-        break;
-      case 'heal':
-        changeHealth('player', 10);
-    };
-    // Clear text area
-    setPlayerInput('')
-  };
+  // if (isMatch(playerInput, playerActions)) {
+  //   const action = playerActions.find(action => action.word === playerInput);
+  //   // Get a new word for that action
+  //   console.log('matched action', action);
+  //   getNewWord(action);
+  //   // Execute the attack or heal action
+  //   switch (action.name) {
+  //     case 'attack':
+  //       changeHealth('challenger', -10);
+  //       break;
+  //     case 'heal':
+  //       changeHealth('player', 10);
+  //   };
+  //   // Clear text area
+  //   setPlayerInput('')
+  // };
 
 
   // Get word list and action list on load

--- a/client/src/components/Canvas/Arena.js
+++ b/client/src/components/Canvas/Arena.js
@@ -104,7 +104,8 @@ function Arena(props) {
     return randWord.word;
   }
   // Returns true if player input matches an action word
-  const isMatch = (input, actions) => actions.find(action => action.word === input);
+  // const isMatch = (input, actions) => actions.find(action => action.word === input);
+  
   // Gets and sets a new word for the given action that the player just executed
   const getNewWord = (action) => {
     setPlayerActions(prev => {

--- a/client/src/components/Canvas/Arena.js
+++ b/client/src/components/Canvas/Arena.js
@@ -16,6 +16,7 @@ import './Arena.scss'
 import updateToArenaBeat from "../../helpers/makeNewArenas";
 // Hooks
 import useInputMatcher from '../../hooks/useInputMatcher';
+import useChallengerAction from '../../hooks/useChallengerAction';
 
 function Arena(props) {
 
@@ -26,7 +27,7 @@ function Arena(props) {
   const [playerActions, setPlayerActions] = useState([]);
   const [health, setHealth] = useState({ player: props.initialPlayerHealth, challenger: props.challengerHealth })
   const [playerInput, setPlayerInput] = useState('');
-
+  const { attackTime, setAttackTime } = useChallengerAction({attackTime: 2000});
   const { handleWordMatch } = useInputMatcher();
 
   // const [match, setMatch] = useState('');
@@ -78,7 +79,7 @@ function Arena(props) {
   }, [health])
 
   // Timings for the challenger's attacks
-  const milliseconds = 1000;
+  const milliseconds = attackTime / 20;
   const [challengerTimer, setChallengerTimer] = useState(20);
 
   // Use a useEffect to prevent looping (otherwise, every time interval is set, the re-render causes a second timer to be started, etc.)
@@ -168,6 +169,11 @@ function Arena(props) {
         />
       </div>
       <div className="challenger-action">
+        <div className="buttons">
+          <button onClick={setAttackTime(1000000000)}>Pause</button>
+          <button onClick={setAttackTime(20000)}>Slow</button>
+          <button onClick={setAttackTime(2000)}>Normal</button>
+        </div>
         <ChallengerActionList
           actions={{
             attack: 'attack-function.jpg',

--- a/client/src/components/Canvas/Arena.scss
+++ b/client/src/components/Canvas/Arena.scss
@@ -14,4 +14,10 @@ main.arena {
   .typing {
     grid-column: span 2;
   }
+
+  div.buttons {
+    display: flex;
+    align-items: center;
+    justify-content: space-around;
+  }
 }

--- a/client/src/components/Canvas/Map.js
+++ b/client/src/components/Canvas/Map.js
@@ -6,6 +6,8 @@ import React from "react";
 import ArenaDoorList from '../ArenaDoorList';
 import { StepProgressBar } from "../MapProgressBar";
 
+// Styles
+import './Map.scss';
 
 // Hooks
 
@@ -13,8 +15,7 @@ function Map(props) {
 
 
   return (
-    <>
-      <h1>Map</h1>
+    <main className="map">
       <StepProgressBar
         arenasBeaten={props.arenasBeaten}
       />
@@ -24,7 +25,7 @@ function Map(props) {
         arenas={props.arenas}
         setArena={props.setArena}
       />
-    </>
+    </main>
   );
 }
 

--- a/client/src/components/Canvas/Map.scss
+++ b/client/src/components/Canvas/Map.scss
@@ -1,17 +1,19 @@
 /* Note that this stylesheet is loaded on all screens. Put all style rules into main.map to prevent it from affecting, say, the arena screen */
 
-main.arena {
+main.map {
   display: grid;
-  grid-template-columns: 1fr 1fr;
-  grid-template-rows: 1fr 3fr 2fr 1fr;
+  grid-template-columns: 1fr 1fr 1fr 1fr 1fr;
+  grid-template-rows: 1fr 1fr 3fr;
   justify-items: center;
-  align-items: center;
 
-  .health {
+  div.RSPBprogressBar {
+    grid-column: span 4;
     width: 90%;
+    padding: 1em;
+    margin: 0.5em;
   }
 
-  .typing {
-    grid-column: span 2;
+  .title {
+    grid-column: span 5;
   }
 }

--- a/client/src/components/Canvas/Outcome/LoseGame.js
+++ b/client/src/components/Canvas/Outcome/LoseGame.js
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const LoseGame = (props) => {
+  return (
+    <>
+      <h1>DEFEAT</h1>
+      <p>Too bad, best of luck next time!</p>
+    </>
+  );
+};

--- a/client/src/components/Canvas/Outcome/LoseGame.js
+++ b/client/src/components/Canvas/Outcome/LoseGame.js
@@ -5,6 +5,7 @@ const LoseGame = (props) => {
     <>
       <h1>DEFEAT</h1>
       <p>Too bad, best of luck next time!</p>
+      <button onClick={() => props.setMode('START')}>Back to Start</button>
     </>
   );
 };

--- a/client/src/components/Canvas/Outcome/LoseGame.js
+++ b/client/src/components/Canvas/Outcome/LoseGame.js
@@ -8,3 +8,4 @@ const LoseGame = (props) => {
     </>
   );
 };
+export default LoseGame;

--- a/client/src/components/Canvas/Outcome/WinBattle.js
+++ b/client/src/components/Canvas/Outcome/WinBattle.js
@@ -8,3 +8,4 @@ const WinBattle = (props) => {
     </>
   );
 };
+export default WinBattle;

--- a/client/src/components/Canvas/Outcome/WinBattle.js
+++ b/client/src/components/Canvas/Outcome/WinBattle.js
@@ -5,6 +5,7 @@ const WinBattle = (props) => {
     <>
       <h1>VICTORY</h1>
       <p>Congrats, you won the fight!</p>
+      <button onClick={() => props.setMode('MAP')}>Choose Next Battle</button>
     </>
   );
 };

--- a/client/src/components/Canvas/Outcome/WinBattle.js
+++ b/client/src/components/Canvas/Outcome/WinBattle.js
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const WinBattle = (props) => {
+  return (
+    <>
+      <h1>VICTORY</h1>
+      <p>Congrats, you won the fight!</p>
+    </>
+  );
+};

--- a/client/src/components/Canvas/Outcome/WinGame.js
+++ b/client/src/components/Canvas/Outcome/WinGame.js
@@ -1,5 +1,6 @@
 import React from 'react';
 
+// Only a template, it is currently not possible to reach this page since boss hasn't been created yet
 const WinGame = (props) => {
   return (
     <>
@@ -9,3 +10,5 @@ const WinGame = (props) => {
     </>
   );
 };
+
+export default WinGame;

--- a/client/src/components/Canvas/Outcome/WinGame.js
+++ b/client/src/components/Canvas/Outcome/WinGame.js
@@ -7,6 +7,7 @@ const WinGame = (props) => {
       <h1>YOU WON!</h1>
       <p>You beat the game! Enter your high score here:</p>
       <p>(Leaderboard goes here)</p>
+      <button onClick={() => props.setMode('START')}>Back to Start</button>
     </>
   );
 };

--- a/client/src/components/Canvas/Outcome/WinGame.js
+++ b/client/src/components/Canvas/Outcome/WinGame.js
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const WinGame = (props) => {
+  return (
+    <>
+      <h1>YOU WON!</h1>
+      <p>You beat the game! Enter your high score here:</p>
+      <p>(Leaderboard goes here)</p>
+    </>
+  );
+};

--- a/client/src/components/Canvas/Outcome/index.js
+++ b/client/src/components/Canvas/Outcome/index.js
@@ -16,9 +16,9 @@ function Outcome(props) {
   return (
     <main class="outcome">
       <h1>Outcome</h1>
-      {result === WINGAME && <WinGame/>}
-      {result === LOSEGAME && <LoseGame/>}
-      {result === WINBATTLE && <WinBattle/>}
+      {result === WINGAME && <WinGame setMode={props.setMode}/>}
+      {result === LOSEGAME && <LoseGame setMode={props.setMode}/>}
+      {result === WINBATTLE && <WinBattle setMode={props.setMode}/>}
       {result === PENDING && <p>Oops, looks like an error occurred. The result state cshouldn't be pending!</p>}
     </main>
   );

--- a/client/src/components/Canvas/Outcome/index.js
+++ b/client/src/components/Canvas/Outcome/index.js
@@ -1,8 +1,10 @@
 import React from "react";
 
-function Outcome() {
+function Outcome(props) {
   return (
-    <h1>Outcome</h1>
+    <main class="outcome">
+      <h1>Outcome</h1>
+    </main>
   );
 }
 

--- a/client/src/components/Canvas/Outcome/index.js
+++ b/client/src/components/Canvas/Outcome/index.js
@@ -1,9 +1,25 @@
 import React from "react";
 
+// Components
+import WinGame from './WinGame';
+import WinBattle from './WinBattle';
+import LoseGame from './LoseGame';
+
 function Outcome(props) {
+
+  const WINGAME = 'WINGAME';
+  const LOSEGAME = 'LOSEGAME';
+  const WINBATTLE = 'WINBATTLE';
+  const PENDING = 'PENDING';
+  const result = props.result;
+
   return (
     <main class="outcome">
       <h1>Outcome</h1>
+      {result === WINGAME && <WinGame/>}
+      {result === LOSEGAME && <LoseGame/>}
+      {result === WINBATTLE && <WinBattle/>}
+      {result === PENDING && <p>Oops, looks like an error occurred. The result state cshouldn't be pending!</p>}
     </main>
   );
 }

--- a/client/src/components/Canvas/Outcome/index.js
+++ b/client/src/components/Canvas/Outcome/index.js
@@ -14,7 +14,7 @@ function Outcome(props) {
   const result = props.result;
 
   return (
-    <main class="outcome">
+    <main className="outcome">
       <h1>Outcome</h1>
       {result === WINGAME && <WinGame setMode={props.setMode}/>}
       {result === LOSEGAME && <LoseGame setMode={props.setMode}/>}

--- a/client/src/components/Canvas/StartGame.js
+++ b/client/src/components/Canvas/StartGame.js
@@ -1,14 +1,24 @@
 // Libraries
 import React from "react";
 
+// Styles
+import './StartGame.scss';
+
 function StartGame(props) {
   return (
-    <>
-    <h1>Start Game</h1>
-    <button
-      onClick={() => {props.setMode("MAP")}}
-    >Start Game</button>
-    </>
+    <main class="start-game">
+      <h1>Start Game</h1>
+      <div class="menu">
+        <button
+          onClick={() => { props.setMode("MAP") }}
+        >Start Game
+        </button>
+        These buttons don't do anything yet:
+        <button>Credits</button>
+        <button>Instructions</button>
+        <button>Settings</button>
+      </div>
+    </main>
   );
 }
 

--- a/client/src/components/Canvas/StartGame.js
+++ b/client/src/components/Canvas/StartGame.js
@@ -6,9 +6,9 @@ import './StartGame.scss';
 
 function StartGame(props) {
   return (
-    <main class="start-game">
+    <main className="start-game">
       <h1>Start Game</h1>
-      <div class="menu">
+      <div className="menu">
         <button
           onClick={() => { props.setMode("MAP") }}
         >Start Game

--- a/client/src/components/Canvas/StartGame.js
+++ b/client/src/components/Canvas/StartGame.js
@@ -13,7 +13,7 @@ function StartGame(props) {
           onClick={() => { props.setMode("MAP") }}
         >Start Game
         </button>
-        These buttons don't do anything yet:
+        (Following buttons don't do anything yet:)
         <button>Credits</button>
         <button>Instructions</button>
         <button>Settings</button>

--- a/client/src/components/Canvas/StartGame.scss
+++ b/client/src/components/Canvas/StartGame.scss
@@ -1,0 +1,17 @@
+main.start-game {
+  display: grid;
+  grid-template-columns: 1fr;
+  justify-items: center;
+
+  .menu {
+    display: flex;
+    flex-direction: column;
+
+    button {
+      justify-content: space-around;
+      align-items: center;
+      margin: 0.5em;
+    }
+
+  }
+}

--- a/client/src/components/Canvas/index.js
+++ b/client/src/components/Canvas/index.js
@@ -2,6 +2,7 @@
 import React from "react";
 import useGameMode from "../../hooks/useGameMode";
 import useArena from "../../hooks/useArena";
+import useResult from '../../hooks/useResult';
 import TempNavBar from '../TempNavBar';
 import lookupArenasBeaten from "../../helpers/lookupArenasBeaten";
 
@@ -27,6 +28,8 @@ function Canvas(props) {
   //hooks
   const { mode, setMode } = useGameMode("START")
   const { arenas, setArenas, arena, setArena } = useArena()
+  const { result, setResult } = useResult('PENDING');
+  // Possible results are: "WinGame", "WinBattle", "LoseGame", "Pending"
   
   return (
     <>
@@ -42,6 +45,7 @@ function Canvas(props) {
           arenasBeaten={lookupArenasBeaten(arenas)} />
       }
         {mode === ARENA && <Arena
+          setResult={setResult}
           initialPlayerHealth = {80}
           challengerHealth = {100}
           setMode={setMode}
@@ -50,6 +54,7 @@ function Canvas(props) {
           setArenas={setArenas}
         />}
         {mode === OUTCOME && <Outcome 
+        result={result}
         setMode={setMode}
         />}
       </div>

--- a/client/src/components/Canvas/index.js
+++ b/client/src/components/Canvas/index.js
@@ -6,7 +6,7 @@ import TempNavBar from '../TempNavBar';
 import lookupArenasBeaten from "../../helpers/lookupArenasBeaten";
 
 // Styles
-// import 'styles/App.css';
+import './index.scss';
 
 // Components
 import StartGame from './StartGame';

--- a/client/src/components/Canvas/index.scss
+++ b/client/src/components/Canvas/index.scss
@@ -1,0 +1,9 @@
+main {
+  width: 80vw;
+  height: 80vh;
+  border: 1px black solid;
+  margin-top: 1em;
+  margin-bottom: 1em;
+  margin-left: auto;
+  margin-right: auto;
+}

--- a/client/src/components/PlayerActionList.js
+++ b/client/src/components/PlayerActionList.js
@@ -4,7 +4,16 @@ import React from "react";
 // Components
 import PlayerAction from './PlayerAction';
 
+// Hooks
+import useInputMatcher from '../hooks/useInputMatcher';
+
+// Styles
+import './PlayerActionList.scss';
+
 function PlayerActionList(props) {
+
+  const { handleLetterMatch } = useInputMatcher();
+  const match = handleLetterMatch(props.playerInput, props.playerActions);
 
   const actions = props.playerActions.map(action => {
     return (
@@ -15,13 +24,13 @@ function PlayerActionList(props) {
       />
     )
   });
-    
+
   return (
     <>
       <h1>PlayerActionList</h1>
-        <ul>
-          {actions}
-        </ul>
+      <ul>
+        {actions}
+      </ul>
     </>
   )
 }

--- a/client/src/components/PlayerActionList.scss
+++ b/client/src/components/PlayerActionList.scss
@@ -1,0 +1,3 @@
+.match {
+  color: red;
+}

--- a/client/src/hooks/useChallengerAction.js
+++ b/client/src/hooks/useChallengerAction.js
@@ -1,2 +1,13 @@
 // controls the challenger's state
 // makes an axios request to challengers to get the name, health, attack time etc
+
+// shifts between each of the game modes: start, map, arena and result
+
+import { useState } from "react";
+
+export default function useChallengerAction(initial) {
+
+  const [attackTime, setAttackTime] = useState(initial['attackTime']);
+
+  return { attackTime, setAttackTime};
+}

--- a/client/src/hooks/useInputMatcher.js
+++ b/client/src/hooks/useInputMatcher.js
@@ -1,0 +1,25 @@
+import { useState } from "react";
+
+export default function useInputMatcher() {
+
+  // const [ isLetterMatch, setIsLetterMatch ] = useState(false);
+  // const [ isWordMatch, setIsWordMatch ] = useState(false);
+
+  // Check for letter matches and returns true if a match is found
+  // playerInput: "word"
+  // playerActions: [{ name: "attack", word: "word"}, { name: "heal", word: "girl" }]
+  const handleLetterMatch = (playerInput, playerActions) => {
+    const actionWordSlices = playerActions.map(action => action.word.slice(0, playerInput.length) || '');
+    return (actionWordSlices.includes(playerInput)) ? true : false;
+  }
+
+  // Check for word matches and returns the action name if a match is found
+  const handleWordMatch = (playerInput, playerActions) => {
+    return playerActions.find(action => action.word === playerInput);
+  }
+
+  return {
+    handleWordMatch,
+    handleLetterMatch
+  }
+}

--- a/client/src/hooks/usePlayerAction.js
+++ b/client/src/hooks/usePlayerAction.js
@@ -7,7 +7,7 @@
 // apply styles => look into useRef (initialize it in component not another hook or return it in useinputmatch hook, destructure in arena component
   // userRef example
     // const textInputRef = useRef(null)
-    // return <span class="match" ref={textInputRef}></span>
+    // return <span className="match" ref={textInputRef}></span>
 
     // access it by textInputRef.current.style.color = "red"
 

--- a/client/src/hooks/usePlayerAction.js
+++ b/client/src/hooks/usePlayerAction.js
@@ -1,2 +1,15 @@
 // controls the player's state - health, words etc
 // Makes an Axios request to words to load the player's words
+
+// usePlayerAction hook
+
+// if letter matches
+// apply styles => look into useRef (initialize it in component not another hook or return it in useinputmatch hook, destructure in arena component
+  // userRef example
+    // const textInputRef = useRef(null)
+    // return <span class="match" ref={textInputRef}></span>
+
+    // access it by textInputRef.current.style.color = "red"
+
+    // console.log(textInputRef.current) => log all the methods 
+// apply styles using Interweave => https://github.com/milesj/interweave

--- a/client/src/hooks/useResult.js
+++ b/client/src/hooks/useResult.js
@@ -1,0 +1,10 @@
+// possible results are:
+
+import { useState } from "react";
+
+export default useResult = (initial) => {
+
+  const [result, setResult] = useState(initial)
+
+  return { result, setResult};
+};

--- a/client/src/hooks/useResult.js
+++ b/client/src/hooks/useResult.js
@@ -2,9 +2,11 @@
 
 import { useState } from "react";
 
-export default useResult = (initial) => {
+const useResult = (initial) => {
 
   const [result, setResult] = useState(initial)
 
   return { result, setResult};
 };
+
+export default useResult;


### PR DESCRIPTION
Changes in this PR:

1) Added a rectangular layout box for the canvas. All screens (map, arena, outcome, start) now fit within it
2) Did a few quick alignment changes for the Map and Start screens
3) Added a new custom hook useResult. A result state is now set when someone reaches 0 health, so the app knows whether to show the win or lose screen
4) Added a few more buttons so it's now possible to navigate between all modes "properly"

This also includes the changes I pair-programmed with Helen earlier today:

5) Word-matching and letter-matching functions were moved to a custom hook called useInputMatcher
6) Word-matching now uses this custom hook, instead of the original convoluted function
7) Letter-matching function has been passed down as a prop to PlayerActionList. Further work is still needed to make the letters highlight in red (and possibly installing a library to avoid XSS)

Also added a second custom hook useChallengerAction. To test this out, there are now buttons for "Pause", "Slow" (attack every 20 s), and "Normal" (Attack every 2 s) that control how fast the challenger attacks. Now you can test the page AND also play the game